### PR TITLE
Use "key" prop for children

### DIFF
--- a/build/react-material-icons.js
+++ b/build/react-material-icons.js
@@ -816,8 +816,8 @@ var MorphIcon = React.createClass({
   },
 
   makeIcons: function makeIcons(shapes) {
-    return this.props.icons.map(function (icon) {
-      return React.createElement('g', { id: icon, dangerouslySetInnerHTML: { __html: shapes[icon] } });
+    return this.props.icons.map(function (icon, i) {
+      return React.createElement('g', { id: icon, key: i, dangerouslySetInnerHTML: { __html: shapes[icon] } });
     });
   },
 

--- a/src/react-material-icons.jsx
+++ b/src/react-material-icons.jsx
@@ -813,8 +813,8 @@ var MorphIcon = React.createClass({
   },
 
   makeIcons(shapes) {
-    return this.props.icons.map((icon) => {
-      return <g id={icon} dangerouslySetInnerHTML={{__html: shapes[icon]}}></g>
+    return this.props.icons.map((icon, i) => {
+      return <g id={icon} key={i} dangerouslySetInnerHTML={{__html: shapes[icon]}}></g>
     });
   },
 


### PR DESCRIPTION
In order to get rid of warning message:
"Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of MorphIcon. See https://fb.me/react-warning-keys for more information."
