### PR TITLE
Added className passthrough to svg object

### DIFF
--- a/src/material-icons.js
+++ b/src/material-icons.js
@@ -58,6 +58,7 @@ export default class MorphIcon extends React.Component {
       viewBox: "0 0 24 24",
       style: props.style,
       ref: "svgBox",
+      className: props.className,
       // Set inner html shapes
       dangerouslySetInnerHTML: { __html: icons }
     };


### PR DESCRIPTION
"className" from the "MorphIcon" object wasn't being passed through to the SVG object. While the "style" tag is being passed, classes can be a preferred method of styling / manipulating objects. 